### PR TITLE
fix code chunk scrolling and line breaks

### DIFF
--- a/css/syntax.css
+++ b/css/syntax.css
@@ -2,17 +2,9 @@
 
 /* to make lines scroll instead of wrap */
 /* from http://stackoverflow.com/a/23393920 */
-
-.highlight pre code * {
-  white-space: nowrap;    // this sets all children inside to nowrap
-}
-
-.highlight pre {
-  overflow-x: auto;       // this sets the scrolling in x
-}
-
 .highlight pre code {
-  white-space: pre;       // forces <code> to respect <pre> formatting
+  white-space: pre;
+  overflow-x: auto; 
 }
 
 /* github style pygments theme for jekyll */


### PR DESCRIPTION
The current css seems to ignore line breaks in code chunks formatted with three backticks, at least when using r syntax highlighting, e.g.:

```
    ```r
    codeline1
    codeline2
    ```
```
is generated as one continuous line:
```
condeline1 condeline2
```
whereas
```
    ```bash
    codeline1
    codeline2
    ```
```
generates:
```
condeline1 
condeline2
```

The edit should fix this, but maintain x-scrolling of long code lines. 